### PR TITLE
Add a typosquat example for a Python library

### DIFF
--- a/python_app/typosquat.py
+++ b/python_app/typosquat.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 
-import requests
+import request
 import sys
 
 url = "https://api.github.com/events"
-response = requests.get(url)
+response = request.get(url)
 
 # Accessing response data
 print(f"Status Code: {response.status_code}")


### PR DESCRIPTION
`request` is a common typosquat for the popular `requests` library.